### PR TITLE
feat: Use smaller T5 model to reduce disk space usage

### DIFF
--- a/models/util.py
+++ b/models/util.py
@@ -424,7 +424,7 @@ def load_flow_model(
 
 def load_t5(device: str | torch.device = "cuda", max_length: int = 512) -> HFEmbedder:
     # max length 64, 128, 256 and 512 should work (if your sequence is short enough)
-    return HFEmbedder("google/t5-v1_1-xxl", max_length=max_length, torch_dtype=torch.bfloat16).to(device)
+    return HFEmbedder("t5-large", max_length=max_length, torch_dtype=torch.bfloat16).to(device)
 
 
 def load_clip(device: str | torch.device = "cuda") -> HFEmbedder:


### PR DESCRIPTION
This change replaces the `google/t5-v1_1-xxl` model with the smaller `t5-large` model. This is intended to resolve the disk space issue that was occurring when downloading the T5 model.

The `t5-large` model is significantly smaller than the `t5-v1_1-xxl` model, but should still provide good performance for the text encoding task.