### PR TITLE
fix: Resolve NotImplementedError for meta device

### DIFF
--- a/visualcloze.py
+++ b/visualcloze.py
@@ -108,14 +108,14 @@ class VisualClozeModel:
         self.t5 = load_t5(text_encoder_device, max_length=self.max_length)
         self.clip = load_clip(text_encoder_device)
         
-        self.model.eval().to(self.device, dtype=self.dtype)
-        
         # Load model weights
         print(f"Loading model weights from {model_path}...")
         ckpt = torch.load(model_path, map_location=self.device)
         self.model.load_state_dict(ckpt, strict=False)
         del ckpt
         
+        self.model.eval().to(self.device, dtype=self.dtype)
+
         # Initialize sampler
         transport = create_transport(
             "Linear",


### PR DESCRIPTION
This change fixes a `NotImplementedError` that was occurring when loading the model. The error was caused by trying to move the model to a different device before the checkpoint was loaded.

The `self.model.eval().to(self.device, dtype=self.dtype)` line has been moved to after the model's state dict is loaded, which resolves the issue.