### PR TITLE
fix: Resolve AttributeError when loading model

### DIFF
--- a/visualcloze.py
+++ b/visualcloze.py
@@ -109,11 +109,12 @@ class VisualClozeModel:
         self.clip = load_clip(text_encoder_device)
         
         # Load model weights
-        print(f"Loading model weights from {model_path}...")
-        ckpt = torch.load(model_path, map_location=self.device)
-        self.model.load_state_dict(ckpt, strict=False)
-        del ckpt
-        
+        if model_path is not None:
+            print(f"Loading model weights from {model_path}...")
+            ckpt = torch.load(model_path, map_location=self.device)
+            self.model.load_state_dict(ckpt, strict=False)
+            del ckpt
+
         self.model.eval().to(self.device, dtype=self.dtype)
 
         # Initialize sampler


### PR DESCRIPTION
This change fixes an `AttributeError` that was occurring when loading the model without a specified model path. The error was caused by trying to call `torch.load` with a `None` value.

A conditional check has been added to `visualcloze.py` to ensure that `torch.load` is only called when a model path is provided.