### PR TITLE
feat: Optimize for virtual try-on and fix memory issues

### DIFF
--- a/models/util.py
+++ b/models/util.py
@@ -387,11 +387,10 @@ def load_flow_model(
     # Loading Flux
     print("Init model")
     lora_path = configs[name].lora_path
-    with torch.device("meta"):
-        if lora_path is not None:
-            model = FluxLoraWrapper(params=configs[name].params, lora_rank=lora_rank, lora_scale=lora_scale).to(torch.bfloat16)
-        else:
-            model = Flux(configs[name].params).to(torch.bfloat16)
+    if lora_path is not None:
+        model = FluxLoraWrapper(params=configs[name].params, lora_rank=lora_rank, lora_scale=lora_scale).to(torch.bfloat16)
+    else:
+        model = Flux(configs[name].params).to(torch.bfloat16)
     return model
 
 

--- a/visualcloze.py
+++ b/visualcloze.py
@@ -96,7 +96,8 @@ class VisualClozeModel:
         
         # Initialize model
         print("Initializing model...")
-        self.model = load_flow_model(model_name, device=self.device, lora_rank=self.lora_rank)
+        self.model = load_flow_model(model_name, device="cpu", lora_rank=self.lora_rank)
+        self.model.to(self.device)
         
         # Download checkpoint if necessary
         ckpt_path = configs[model_name].ckpt_path
@@ -107,8 +108,7 @@ class VisualClozeModel:
         # Load checkpoint
         print(f"Loading checkpoint from {ckpt_path}...")
         state_dict = load_sft(ckpt_path, device=str(self.device))
-        state_dict = optionally_expand_state_dict(self.model, state_dict)
-        self.model.load_state_dict(state_dict, strict=False, assign=True)
+        self.model.load_state_dict(state_dict, strict=False)
         del state_dict
 
         # Initialize VAE
@@ -130,7 +130,7 @@ class VisualClozeModel:
             self.model.load_state_dict(ckpt, strict=False)
             del ckpt
 
-        self.model.eval().to(self.device, dtype=self.dtype)
+        self.model.eval()
 
         # Initialize sampler
         transport = create_transport(


### PR DESCRIPTION
This change introduces a number of optimizations and fixes to address memory and disk space issues, and to streamline the application for the virtual try-on task.

The key changes are:

- A new, stripped-down application, `app_tryon.py`, has been created for the virtual try-on task. This application has a simplified UI and only loads the components necessary for this task.
- The T5 model has been changed from `google/t5-v1_1-xxl` to `t5-large` to reduce disk space usage.
- A `--low_vram` mode has been added to offload the VAE and text encoders to the CPU when not in use.
- The model loading process has been modified to prevent errors related to 'meta' device initialization and `None` model paths.
- `SyntaxWarning`s in the example files have been fixed.