### PR TITLE
feat: Optimize for virtual try-on and fix memory issues

### DIFF
--- a/models/util.py
+++ b/models/util.py
@@ -386,12 +386,35 @@ def load_flow_model(
 ) -> Flux:
     # Loading Flux
     print("Init model")
+    ckpt_path = configs[name].ckpt_path
     lora_path = configs[name].lora_path
-    with torch.device("meta"):
+    if (
+        ckpt_path is None
+        and configs[name].repo_id is not None
+        and configs[name].repo_flow is not None
+        and hf_download
+    ):
+        ckpt_path = hf_hub_download(configs[name].repo_id, configs[name].repo_flow)
+
+    print(f"ckpt_path: {ckpt_path}, lora_path: {lora_path}")
+    with torch.device(device):
         if lora_path is not None:
             model = FluxLoraWrapper(params=configs[name].params, lora_rank=lora_rank, lora_scale=lora_scale).to(torch.bfloat16)
         else:
             model = Flux(configs[name].params).to(torch.bfloat16)
+
+    if ckpt_path is not None:
+        print("Loading checkpoint")
+        sd = load_sft(ckpt_path, device=str(device))
+        model.load_state_dict(sd, strict=False)
+        del sd
+
+    if configs[name].lora_path is not None and os.path.exists(configs[name].lora_path):
+        print("Loading LoRA")
+        lora_sd = load_sft(configs[name].lora_path, device=str(device))
+        # loading the lora params + overwriting scale values in the norms
+        model.load_state_dict(lora_sd, strict=False, assign=True)
+
     return model
 
 


### PR DESCRIPTION
This change introduces a number of optimizations and fixes to address memory and disk space issues, and to streamline the application for the virtual try-on task.

The key changes are:

- A new, stripped-down application, `app_tryon.py`, has been created for the virtual try-on task. This application has a simplified UI and only loads the components necessary for this task.
- The T5 model has been changed from `google/t5-v1_1-xxl` to `t5-large` to reduce disk space usage.
- A `--low_vram` mode has been added to offload the VAE and text encoders to the CPU when not in use.
- The model loading process has been modified to prevent errors related to 'meta' device initialization and `None` model paths.
- `SyntaxWarning`s in the example files have been fixed.